### PR TITLE
feat(xcmd): support nested subcommands of arbitrary depth

### DIFF
--- a/xcmd/README.md
+++ b/xcmd/README.md
@@ -122,7 +122,7 @@ run => {
 
 Subcommands can be nested to arbitrary depth. The file name convention uses underscores to separate levels. The framework resolves the parent command by scanning underscore positions in the file name from right to left, trying the longest possible parent first and falling back to shorter prefixes until a registered parent is found.
 
-The example below builds a `mod tool` command group with `list` and `add` subcommands. Because `mod tool` is a two-level path, both the top-level `mod` command file (from the earlier [Subcommand](#subcommand) section) and the intermediate `mod_tool_cmd.gox` must exist — otherwise `mod_tool_list_cmd.gox` would fall back to a root-level command named `mod_tool_list`.
+The example below builds a `mod tool` command group with `list` and `add` subcommands. Because `mod tool` is a two-level path, both the top-level `mod` command file (from the earlier [Subcommand](#subcommand) section) and the intermediate `mod_tool_cmd.gox` must exist — otherwise `mod_tool_list_cmd.gox` would fall back to the next longest matching parent (e.g. to `mod` as a root command named `tool_list`), or to a root-level command named `mod_tool_list` if no parent matches.
 
 Ensure `mod_cmd.gox` from the previous section already exists:
 

--- a/xcmd/README.md
+++ b/xcmd/README.md
@@ -117,3 +117,49 @@ run => {
 	echo "subcommand: mod init"
 }
 ```
+
+## Nested subcommands
+
+Subcommands can be nested to arbitrary depth. The file name convention uses underscores to separate levels. The framework resolves parents by matching the longest classfile name from right to left.
+
+For example, to create a `mod tool` command group with `list` and `add` subcommands:
+
+Create `mod_tool_cmd.gox`:
+
+```go
+short "manage module tools"
+
+run => {
+	help
+}
+```
+
+Create `mod_tool_list_cmd.gox`:
+
+```go
+short "list installed tools"
+
+run => {
+	echo "listing installed tools..."
+}
+```
+
+Create `mod_tool_add_cmd.gox`:
+
+```go
+use "add <tool>"
+
+short "add a tool dependency"
+
+run args => {
+	echo "adding tool:", args
+}
+```
+
+This produces the following command tree:
+
+```
+hellocli mod tool          # manage module tools
+hellocli mod tool list     # list installed tools
+hellocli mod tool add      # add a tool dependency
+```

--- a/xcmd/README.md
+++ b/xcmd/README.md
@@ -120,9 +120,17 @@ run => {
 
 ## Nested subcommands
 
-Subcommands can be nested to arbitrary depth. The file name convention uses underscores to separate levels. The framework resolves parents by matching the longest classfile name from right to left.
+Subcommands can be nested to arbitrary depth. The file name convention uses underscores to separate levels. The framework resolves the parent command by scanning underscore positions in the file name from right to left, trying the longest possible parent first and falling back to shorter prefixes until a registered parent is found.
 
-For example, to create a `mod tool` command group with `list` and `add` subcommands:
+The example below builds a `mod tool` command group with `list` and `add` subcommands. Because `mod tool` is a two-level path, both the top-level `mod` command file (from the earlier [Subcommand](#subcommand) section) and the intermediate `mod_tool_cmd.gox` must exist — otherwise `mod_tool_list_cmd.gox` would fall back to a root-level command named `mod_tool_list`.
+
+Ensure `mod_cmd.gox` from the previous section already exists:
+
+```go
+run => {
+	help
+}
+```
 
 Create `mod_tool_cmd.gox`:
 

--- a/xcmd/classfile.go
+++ b/xcmd/classfile.go
@@ -135,19 +135,24 @@ func XGot_App_Main(app iAppProto, cmds ...iCommandProto) {
 	root.Execute()
 }
 
+// parentAndCmdName resolves the parent command for a given classfile name by
+// scanning underscore positions from right to left. This allows nested
+// subcommands of arbitrary depth. For example, "sandbox_template_list" first
+// tries parent "sandbox_template" (name "list"), then falls back to "sandbox"
+// (name "template_list"). If no parent is found the command is attached to root.
 func parentAndCmdName(root *Command, cmds []iCommandProto, fname string) (*cobra.Command, string) {
-	pos := strings.IndexByte(fname, '_')
-	if pos < 0 {
-		return &root.Command, fname
-	}
-	subcmd, name := fname[:pos], fname[pos+1:]
-	for _, v := range cmds {
-		if v.Classfname() == subcmd {
-			return v.cobraCmd(), name
+	for i := len(fname) - 1; i >= 0; i-- {
+		if fname[i] != '_' {
+			continue
+		}
+		parent, name := fname[:i], fname[i+1:]
+		for _, v := range cmds {
+			if v.Classfname() == parent {
+				return v.cobraCmd(), name
+			}
 		}
 	}
-	log.Panicf("Command `%s %s`: parent command not found", subcmd, name)
-	return nil, ""
+	return &root.Command, fname
 }
 
 func handleFlags(self *cobra.Command, v reflect.Value) {

--- a/xcmd/classfile.go
+++ b/xcmd/classfile.go
@@ -149,6 +149,12 @@ func parentAndCmdName(root *Command, cmds []iCommandProto, fname string) (*cobra
 	for i := strings.LastIndexByte(fname, '_'); i >= 0; i = strings.LastIndexByte(fname[:i], '_') {
 		hasUnderscore = true
 		parent, name := fname[:i], fname[i+1:]
+		// Skip degenerate splits (e.g. trailing underscore yields empty name,
+		// consecutive underscores yield empty parent). Continue searching at
+		// the next underscore position so a valid parent can still match.
+		if parent == "" || name == "" {
+			continue
+		}
 		for _, v := range cmds {
 			if v.Classfname() == parent {
 				return v.cobraCmd(), name

--- a/xcmd/classfile.go
+++ b/xcmd/classfile.go
@@ -136,21 +136,27 @@ func XGot_App_Main(app iAppProto, cmds ...iCommandProto) {
 }
 
 // parentAndCmdName resolves the parent command for a given classfile name by
-// scanning underscore positions from right to left. This allows nested
-// subcommands of arbitrary depth. For example, "sandbox_template_list" first
-// tries parent "sandbox_template" (name "list"), then falls back to "sandbox"
-// (name "template_list"). If no parent is found the command is attached to root.
+// scanning underscore positions in fname from right to left. This allows
+// nested subcommands of arbitrary depth. For example, "sandbox_template_list"
+// first tries parent "sandbox_template" (name "list"), then falls back to
+// "sandbox" (name "template_list"). If no parent matches, the command is
+// attached to root with its full classfile name preserved as the command name
+// (e.g. "unknown_sub_deep" becomes a root command named "unknown_sub_deep").
+// When fname contains underscores but no parent matches, a warning is logged
+// to surface likely misregistrations such as typos or missing parent files.
 func parentAndCmdName(root *Command, cmds []iCommandProto, fname string) (*cobra.Command, string) {
-	for i := len(fname) - 1; i >= 0; i-- {
-		if fname[i] != '_' {
-			continue
-		}
+	hasUnderscore := false
+	for i := strings.LastIndexByte(fname, '_'); i >= 0; i = strings.LastIndexByte(fname[:i], '_') {
+		hasUnderscore = true
 		parent, name := fname[:i], fname[i+1:]
 		for _, v := range cmds {
 			if v.Classfname() == parent {
 				return v.cobraCmd(), name
 			}
 		}
+	}
+	if hasUnderscore {
+		log.Printf("xcmd: command %q has no matching parent, attaching to root", fname)
 	}
 	return &root.Command, fname
 }

--- a/xcmd/classfile_test.go
+++ b/xcmd/classfile_test.go
@@ -17,6 +17,9 @@
 package xcmd
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/goplus/cobra"
@@ -88,9 +91,40 @@ func TestParentAndCmdName(t *testing.T) {
 		t.Fatalf("version: got parent=%p name=%q, want root", parent, name)
 	}
 
-	// Fallback: "unknown_sub_deep" with no matching parent → root, full name
+	// Intermediate fallback: "sandbox_templating_list" → rightmost split
+	// "sandbox_templating" is not registered, but fallback matches "sandbox"
+	// with the remainder "templating_list" as the command name.
+	parent, name = parentAndCmdName(root, cmds, "sandbox_templating_list")
+	if parent != sandbox.cobraCmd() || name != "templating_list" {
+		t.Fatalf("sandbox_templating_list: got parent=%p name=%q, want sandbox cmd with name=templating_list", parent, name)
+	}
+
+	// Fallback: "unknown_sub_deep" with no matching parent → root, full name.
+	// Also verifies that a warning is emitted for underscore-containing names
+	// that find no parent, surfacing likely misregistrations.
+	var logBuf bytes.Buffer
+	origOutput := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
 	parent, name = parentAndCmdName(root, cmds, "unknown_sub_deep")
+	log.SetOutput(origOutput)
+	log.SetFlags(origFlags)
 	if parent != &root.Command || name != "unknown_sub_deep" {
 		t.Fatalf("unknown_sub_deep: got parent=%p name=%q, want root with full name", parent, name)
+	}
+	if !strings.Contains(logBuf.String(), `"unknown_sub_deep"`) {
+		t.Fatalf("unknown_sub_deep: expected warning log, got %q", logBuf.String())
+	}
+
+	// Top-level with no underscore must not emit a warning.
+	logBuf.Reset()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	parentAndCmdName(root, cmds, "version")
+	log.SetOutput(origOutput)
+	log.SetFlags(origFlags)
+	if logBuf.Len() != 0 {
+		t.Fatalf("version: expected no warning log, got %q", logBuf.String())
 	}
 }

--- a/xcmd/classfile_test.go
+++ b/xcmd/classfile_test.go
@@ -105,11 +105,13 @@ func TestParentAndCmdName(t *testing.T) {
 	var logBuf bytes.Buffer
 	origOutput := log.Writer()
 	origFlags := log.Flags()
+	defer func() {
+		log.SetOutput(origOutput)
+		log.SetFlags(origFlags)
+	}()
 	log.SetOutput(&logBuf)
 	log.SetFlags(0)
 	parent, name = parentAndCmdName(root, cmds, "unknown_sub_deep")
-	log.SetOutput(origOutput)
-	log.SetFlags(origFlags)
 	if parent != &root.Command || name != "unknown_sub_deep" {
 		t.Fatalf("unknown_sub_deep: got parent=%p name=%q, want root with full name", parent, name)
 	}
@@ -119,11 +121,7 @@ func TestParentAndCmdName(t *testing.T) {
 
 	// Top-level with no underscore must not emit a warning.
 	logBuf.Reset()
-	log.SetOutput(&logBuf)
-	log.SetFlags(0)
 	parentAndCmdName(root, cmds, "version")
-	log.SetOutput(origOutput)
-	log.SetFlags(origFlags)
 	if logBuf.Len() != 0 {
 		t.Fatalf("version: expected no warning log, got %q", logBuf.String())
 	}

--- a/xcmd/classfile_test.go
+++ b/xcmd/classfile_test.go
@@ -19,6 +19,7 @@ package xcmd
 import (
 	"bytes"
 	"log"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -70,59 +71,100 @@ func TestParentAndCmdName(t *testing.T) {
 
 	sandbox := &mockCmd{fname: "sandbox"}
 	sandboxTpl := &mockCmd{fname: "sandbox_template"}
-
 	cmds := []iCommandProto{sandbox, sandboxTpl}
 
-	// Two-level: "sandbox_list" → parent is sandbox, name is "list"
-	parent, name := parentAndCmdName(root, cmds, "sandbox_list")
-	if parent != sandbox.cobraCmd() || name != "list" {
-		t.Fatalf("sandbox_list: got parent=%p name=%q, want sandbox cmd", parent, name)
+	// rootParent is a sentinel resolved at runtime to &root.Command; table
+	// entries refer to it by comparing pointer identity in the assertion.
+	rootParent := &root.Command
+
+	tests := []struct {
+		name       string
+		fname      string
+		wantParent *cobra.Command
+		wantName   string
+		// wantWarn requires a warning log to be emitted; wantNoWarn asserts
+		// silence. Both default to false, which skips the log check.
+		wantWarn   bool
+		wantNoWarn bool
+	}{
+		{
+			name:       "two-level match",
+			fname:      "sandbox_list",
+			wantParent: sandbox.cobraCmd(),
+			wantName:   "list",
+			wantNoWarn: true,
+		},
+		{
+			name:       "three-level match",
+			fname:      "sandbox_template_list",
+			wantParent: sandboxTpl.cobraCmd(),
+			wantName:   "list",
+			wantNoWarn: true,
+		},
+		{
+			name:       "top-level no underscore",
+			fname:      "version",
+			wantParent: rootParent,
+			wantName:   "version",
+			wantNoWarn: true,
+		},
+		{
+			// Rightmost split "sandbox_templating" is not registered; the
+			// algorithm falls back to "sandbox" with the remainder as name.
+			name:       "intermediate fallback",
+			fname:      "sandbox_templating_list",
+			wantParent: sandbox.cobraCmd(),
+			wantName:   "templating_list",
+			wantNoWarn: true,
+		},
+		{
+			// Underscore-containing name with no matching parent falls back
+			// to root with the full fname; a warning surfaces the likely
+			// misregistration.
+			name:       "unmatched underscore name warns",
+			fname:      "unknown_sub_deep",
+			wantParent: rootParent,
+			wantName:   "unknown_sub_deep",
+			wantWarn:   true,
+		},
+		{
+			// Trailing underscore yields an empty name on the first split;
+			// that candidate must be skipped so the valid parent can match.
+			name:       "trailing underscore skips empty name",
+			fname:      "sandbox_",
+			wantParent: rootParent,
+			wantName:   "sandbox_",
+			wantWarn:   true,
+		},
 	}
 
-	// Three-level: "sandbox_template_list" → parent is sandbox_template, name is "list"
-	parent, name = parentAndCmdName(root, cmds, "sandbox_template_list")
-	if parent != sandboxTpl.cobraCmd() || name != "list" {
-		t.Fatalf("sandbox_template_list: got parent=%p name=%q, want sandbox_template cmd", parent, name)
-	}
-
-	// Top-level: "version" → parent is root, name is "version"
-	parent, name = parentAndCmdName(root, cmds, "version")
-	if parent != &root.Command || name != "version" {
-		t.Fatalf("version: got parent=%p name=%q, want root", parent, name)
-	}
-
-	// Intermediate fallback: "sandbox_templating_list" → rightmost split
-	// "sandbox_templating" is not registered, but fallback matches "sandbox"
-	// with the remainder "templating_list" as the command name.
-	parent, name = parentAndCmdName(root, cmds, "sandbox_templating_list")
-	if parent != sandbox.cobraCmd() || name != "templating_list" {
-		t.Fatalf("sandbox_templating_list: got parent=%p name=%q, want sandbox cmd with name=templating_list", parent, name)
-	}
-
-	// Fallback: "unknown_sub_deep" with no matching parent → root, full name.
-	// Also verifies that a warning is emitted for underscore-containing names
-	// that find no parent, surfacing likely misregistrations.
-	var logBuf bytes.Buffer
 	origOutput := log.Writer()
 	origFlags := log.Flags()
 	defer func() {
 		log.SetOutput(origOutput)
 		log.SetFlags(origFlags)
 	}()
-	log.SetOutput(&logBuf)
 	log.SetFlags(0)
-	parent, name = parentAndCmdName(root, cmds, "unknown_sub_deep")
-	if parent != &root.Command || name != "unknown_sub_deep" {
-		t.Fatalf("unknown_sub_deep: got parent=%p name=%q, want root with full name", parent, name)
-	}
-	if !strings.Contains(logBuf.String(), `"unknown_sub_deep"`) {
-		t.Fatalf("unknown_sub_deep: expected warning log, got %q", logBuf.String())
-	}
 
-	// Top-level with no underscore must not emit a warning.
-	logBuf.Reset()
-	parentAndCmdName(root, cmds, "version")
-	if logBuf.Len() != 0 {
-		t.Fatalf("version: expected no warning log, got %q", logBuf.String())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			log.SetOutput(&logBuf)
+
+			gotParent, gotName := parentAndCmdName(root, cmds, tc.fname)
+
+			if gotParent != tc.wantParent {
+				t.Fatalf("parent: got %p, want %p", gotParent, tc.wantParent)
+			}
+			if gotName != tc.wantName {
+				t.Fatalf("name: got %q, want %q", gotName, tc.wantName)
+			}
+			switch {
+			case tc.wantWarn && !strings.Contains(logBuf.String(), strconv.Quote(tc.fname)):
+				t.Fatalf("expected warning log mentioning %q, got %q", tc.fname, logBuf.String())
+			case tc.wantNoWarn && logBuf.Len() != 0:
+				t.Fatalf("expected no warning log, got %q", logBuf.String())
+			}
+		})
 	}
 }

--- a/xcmd/classfile_test.go
+++ b/xcmd/classfile_test.go
@@ -18,6 +18,8 @@ package xcmd
 
 import (
 	"testing"
+
+	"github.com/goplus/cobra"
 )
 
 func TestParseFlag(t *testing.T) {
@@ -47,4 +49,48 @@ func TestParseFlag(t *testing.T) {
 		}
 	}()
 	parseFlag("verbose, unknown:")
+}
+
+// mockCmd implements iCommandProto for testing parentAndCmdName.
+type mockCmd struct {
+	cmd   cobra.Command
+	fname string
+}
+
+func (m *mockCmd) cobraCmd() *cobra.Command { return &m.cmd }
+func (m *mockCmd) Main(name string)         { m.cmd.Use = name }
+func (m *mockCmd) Classfname() string       { return m.fname }
+
+func TestParentAndCmdName(t *testing.T) {
+	root := &Command{}
+	root.Use("app")
+
+	sandbox := &mockCmd{fname: "sandbox"}
+	sandboxTpl := &mockCmd{fname: "sandbox_template"}
+
+	cmds := []iCommandProto{sandbox, sandboxTpl}
+
+	// Two-level: "sandbox_list" → parent is sandbox, name is "list"
+	parent, name := parentAndCmdName(root, cmds, "sandbox_list")
+	if parent != sandbox.cobraCmd() || name != "list" {
+		t.Fatalf("sandbox_list: got parent=%p name=%q, want sandbox cmd", parent, name)
+	}
+
+	// Three-level: "sandbox_template_list" → parent is sandbox_template, name is "list"
+	parent, name = parentAndCmdName(root, cmds, "sandbox_template_list")
+	if parent != sandboxTpl.cobraCmd() || name != "list" {
+		t.Fatalf("sandbox_template_list: got parent=%p name=%q, want sandbox_template cmd", parent, name)
+	}
+
+	// Top-level: "version" → parent is root, name is "version"
+	parent, name = parentAndCmdName(root, cmds, "version")
+	if parent != &root.Command || name != "version" {
+		t.Fatalf("version: got parent=%p name=%q, want root", parent, name)
+	}
+
+	// Fallback: "unknown_sub_deep" with no matching parent → root, full name
+	parent, name = parentAndCmdName(root, cmds, "unknown_sub_deep")
+	if parent != &root.Command || name != "unknown_sub_deep" {
+		t.Fatalf("unknown_sub_deep: got parent=%p name=%q, want root with full name", parent, name)
+	}
 }

--- a/xcmd/demo/godemo/mod_tool_add_cmd.gox
+++ b/xcmd/demo/godemo/mod_tool_add_cmd.gox
@@ -1,0 +1,7 @@
+use "add <tool>"
+
+short "add a tool dependency"
+
+run args => {
+	echo "adding tool:", args
+}

--- a/xcmd/demo/godemo/mod_tool_cmd.gox
+++ b/xcmd/demo/godemo/mod_tool_cmd.gox
@@ -1,0 +1,5 @@
+short "manage module tools"
+
+run => {
+	help
+}

--- a/xcmd/demo/godemo/mod_tool_list_cmd.gox
+++ b/xcmd/demo/godemo/mod_tool_list_cmd.gox
@@ -1,0 +1,5 @@
+short "list installed tools"
+
+run => {
+	echo "listing installed tools..."
+}

--- a/xcmd/demo/godemo/xgo_autogen.go
+++ b/xcmd/demo/godemo/xgo_autogen.go
@@ -26,6 +26,18 @@ type Cmd_mod_init struct {
 	LLGo    bool `flag:"llgo, val: true, usage: use LLGo as underlying compiler"`
 	Verbose bool `flag:"verbose, short: v, usage: print verbose information"`
 }
+type Cmd_mod_tool_add struct {
+	xcmd.Command
+	*App
+}
+type Cmd_mod_tool struct {
+	xcmd.Command
+	*App
+}
+type Cmd_mod_tool_list struct {
+	xcmd.Command
+	*App
+}
 type Cmd_version struct {
 	xcmd.Command
 	*App
@@ -40,8 +52,11 @@ func (this *App) Main() {
 	_xgo_obj0 := &Cmd_backward{App: this}
 	_xgo_obj1 := &Cmd_mod{App: this}
 	_xgo_obj2 := &Cmd_mod_init{App: this}
-	_xgo_obj3 := &Cmd_version{App: this}
-	xcmd.XGot_App_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3)
+	_xgo_obj3 := &Cmd_mod_tool_add{App: this}
+	_xgo_obj4 := &Cmd_mod_tool{App: this}
+	_xgo_obj5 := &Cmd_mod_tool_list{App: this}
+	_xgo_obj6 := &Cmd_version{App: this}
+	xcmd.XGot_App_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3, _xgo_obj4, _xgo_obj5, _xgo_obj6)
 }
 //line xcmd/demo/godemo/backward_cmd.gox:1
 func (this *Cmd_backward) Main(_xgo_arg0 string) {
@@ -107,6 +122,50 @@ See https://golang.org/ref/mod#go-mod-init for more about 'go mod init'.
 }
 func (this *Cmd_mod_init) Classfname() string {
 	return "mod_init"
+}
+//line xcmd/demo/godemo/mod_tool_add_cmd.gox:1
+func (this *Cmd_mod_tool_add) Main(_xgo_arg0 string) {
+	this.Command.Main(_xgo_arg0)
+//line xcmd/demo/godemo/mod_tool_add_cmd.gox:1:1
+	this.Use("add <tool>")
+//line xcmd/demo/godemo/mod_tool_add_cmd.gox:3:1
+	this.Short("add a tool dependency")
+//line xcmd/demo/godemo/mod_tool_add_cmd.gox:5:1
+	this.Run__1(func(args []string) {
+//line xcmd/demo/godemo/mod_tool_add_cmd.gox:6:1
+		fmt.Println("adding tool:", args)
+	})
+}
+func (this *Cmd_mod_tool_add) Classfname() string {
+	return "mod_tool_add"
+}
+//line xcmd/demo/godemo/mod_tool_cmd.gox:1
+func (this *Cmd_mod_tool) Main(_xgo_arg0 string) {
+	this.Command.Main(_xgo_arg0)
+//line xcmd/demo/godemo/mod_tool_cmd.gox:1:1
+	this.Short("manage module tools")
+//line xcmd/demo/godemo/mod_tool_cmd.gox:3:1
+	this.Run__0(func() {
+//line xcmd/demo/godemo/mod_tool_cmd.gox:4:1
+		this.Help()
+	})
+}
+func (this *Cmd_mod_tool) Classfname() string {
+	return "mod_tool"
+}
+//line xcmd/demo/godemo/mod_tool_list_cmd.gox:1
+func (this *Cmd_mod_tool_list) Main(_xgo_arg0 string) {
+	this.Command.Main(_xgo_arg0)
+//line xcmd/demo/godemo/mod_tool_list_cmd.gox:1:1
+	this.Short("list installed tools")
+//line xcmd/demo/godemo/mod_tool_list_cmd.gox:3:1
+	this.Run__0(func() {
+//line xcmd/demo/godemo/mod_tool_list_cmd.gox:4:1
+		fmt.Println("listing installed tools...")
+	})
+}
+func (this *Cmd_mod_tool_list) Classfname() string {
+	return "mod_tool_list"
 }
 //line xcmd/demo/godemo/version_cmd.gox:5
 func (this *Cmd_version) Main(_xgo_arg0 string) {


### PR DESCRIPTION
## Summary
- add support for nested subcommands with arbitrary depth in xcmd
- add three-level nested subcommand demo and documentation
- update README with nested subcommands section

## Commits
- feat(xcmd): support nested subcommands of arbitrary depth
- docs(xcmd): add three-level nested subcommand demo
- docs(xcmd): add nested subcommands section to README